### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/work-in-progress/mozilla/first-letter-characters/first-letter-characters-generator.py
+++ b/work-in-progress/mozilla/first-letter-characters/first-letter-characters-generator.py
@@ -70,11 +70,11 @@ class UnicodeTestGenerator:
             if isSurrogateOrPUA(charname) or not isValidXMLChar(charcode):
                 pass
             elif charname.endswith(", First>"):
-                if rangefirst != None:
+                if rangefirst is not None:
                     raise SyntaxError
                 rangefirst = charcode
             elif charname.endswith(", Last>"):
-                if rangefirst == None:
+                if rangefirst is None:
                     raise SyntaxError
                 if rangefirst >= breakat:
                     # we've exceeded our chunking size; break to a new file
@@ -86,7 +86,7 @@ class UnicodeTestGenerator:
                     self.writeTest(c, ispunct)
                 rangefirst = None
             else:
-                if rangefirst != None:
+                if rangefirst is not None:
                     raise SyntaxError
                 if charcode >= breakat:
                     # we've exceeded our chunking size; break to a new file

--- a/work-in-progress/opera/css-device-adapt/generate-tests.py
+++ b/work-in-progress/opera/css-device-adapt/generate-tests.py
@@ -14,7 +14,7 @@ class TestGenerator:
         self.vendor = vendor
         self.output_dir = output_dir
         extMatch = re.search("\.([^\.]+)$", template_file.name)
-        if extMatch == None:
+        if extMatch is None:
             self.ext = "html"
         else:
             self.ext = extMatch.group(1)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:csswg-test?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:csswg-test?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
