### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/css-fonts-3/support/fonts/makegsubfonts.py
+++ b/css-fonts-3/support/fonts/makegsubfonts.py
@@ -107,7 +107,7 @@ def makeLookup1():
     for index, tag in enumerate(features):
     
     	# tag.pass
-    	glyphName = "%s.pass" % tag
+    	glyphName = "{0!s}.pass".format(tag)
     	glyphOrder.append(glyphName)
     	addGlyphToCFF(
     		glyphName=glyphName,
@@ -124,11 +124,11 @@ def makeLookup1():
     		if table.format == 4:
     			table.cmap[cp] = glyphName
     		else:
-    			raise NotImplementedError, "Unsupported cmap table format: %d" % table.format
+    			raise NotImplementedError, "Unsupported cmap table format: {0:d}".format(table.format)
     	cp += 1
     
     	# tag.fail
-    	glyphName = "%s.fail" % tag
+    	glyphName = "{0!s}.fail".format(tag)
     	glyphOrder.append(glyphName)
     	addGlyphToCFF(
     		glyphName=glyphName,
@@ -145,7 +145,7 @@ def makeLookup1():
     		if table.format == 4:
     			table.cmap[cp] = glyphName
     		else:
-    			raise NotImplementedError, "Unsupported cmap table format: %d" % table.format
+    			raise NotImplementedError, "Unsupported cmap table format: {0:d}".format(table.format)
 
         # bump this up so that the sequence is the same as the lookup 3 font
     	cp += 3
@@ -209,8 +209,8 @@ def makeLookup1():
         subtable.Format = 2
         subtable.LookupType = 1
         subtable.mapping = {
-            "%s.pass" % tag : "%s.fail" % tag,
-            "%s.fail" % tag : "%s.pass" % tag,
+            "{0!s}.pass".format(tag) : "{0!s}.fail".format(tag),
+            "{0!s}.fail".format(tag) : "{0!s}.pass".format(tag),
         }
         lookup.SubTable.append(subtable)
     
@@ -281,7 +281,7 @@ def makeLookup3():
     for index, tag in enumerate(features):
     
     	# tag.pass
-    	glyphName = "%s.pass" % tag
+    	glyphName = "{0!s}.pass".format(tag)
     	glyphOrder.append(glyphName)
     	addGlyphToCFF(
     		glyphName=glyphName,
@@ -295,7 +295,7 @@ def makeLookup3():
     	hmtx[glyphName] = passGlyphMetrics
      
     	# tag.fail
-    	glyphName = "%s.fail" % tag
+    	glyphName = "{0!s}.fail".format(tag)
     	glyphOrder.append(glyphName)
     	addGlyphToCFF(
     		glyphName=glyphName,
@@ -309,7 +309,7 @@ def makeLookup3():
     	hmtx[glyphName] = failGlyphMetrics
      
     	# tag.default
-    	glyphName = "%s.default" % tag
+    	glyphName = "{0!s}.default".format(tag)
     	glyphOrder.append(glyphName)
     	addGlyphToCFF(
     		glyphName=glyphName,
@@ -326,12 +326,12 @@ def makeLookup3():
     		if table.format == 4:
     			table.cmap[cp] = glyphName
     		else:
-    			raise NotImplementedError, "Unsupported cmap table format: %d" % table.format
+    			raise NotImplementedError, "Unsupported cmap table format: {0:d}".format(table.format)
     	cp += 1
     
     	# tag.alt1,2,3
     	for i in range(1,4):
-    		glyphName = "%s.alt%d" % (tag, i)
+    		glyphName = "{0!s}.alt{1:d}".format(tag, i)
     		glyphOrder.append(glyphName)
     		addGlyphToCFF(
     			glyphName=glyphName,
@@ -347,7 +347,7 @@ def makeLookup3():
     			if table.format == 4:
     				table.cmap[cp] = glyphName
     			else:
-    				raise NotImplementedError, "Unsupported cmap table format: %d" % table.format
+    				raise NotImplementedError, "Unsupported cmap table format: {0:d}".format(table.format)
     		cp += 1
     	
     # set the glyph order
@@ -409,10 +409,10 @@ def makeLookup3():
     	subtable.Format = 1
     	subtable.LookupType = 3
     	subtable.alternates = {
-    		"%s.default" % tag : ["%s.fail" % tag, "%s.fail" % tag, "%s.fail" % tag],
-    		"%s.alt1" % tag    : ["%s.pass" % tag, "%s.fail" % tag, "%s.fail" % tag],
-    		"%s.alt2" % tag    : ["%s.fail" % tag, "%s.pass" % tag, "%s.fail" % tag],
-    		"%s.alt3" % tag    : ["%s.fail" % tag, "%s.fail" % tag, "%s.pass" % tag]
+    		"{0!s}.default".format(tag) : ["{0!s}.fail".format(tag), "{0!s}.fail".format(tag), "{0!s}.fail".format(tag)],
+    		"{0!s}.alt1".format(tag)    : ["{0!s}.pass".format(tag), "{0!s}.fail".format(tag), "{0!s}.fail".format(tag)],
+    		"{0!s}.alt2".format(tag)    : ["{0!s}.fail".format(tag), "{0!s}.pass".format(tag), "{0!s}.fail".format(tag)],
+    		"{0!s}.alt3".format(tag)    : ["{0!s}.fail".format(tag), "{0!s}.fail".format(tag), "{0!s}.pass".format(tag)]
     	}
     	lookup.SubTable.append(subtable)
     
@@ -457,7 +457,7 @@ def makeJavascriptData():
 
     taglist = []
     for tag in features:
-        taglist.append("\"%s\": 0x%x" % (tag, cp))
+        taglist.append("\"{0!s}\": 0x{1:x}".format(tag, cp))
         cp += 4
     
     outStr.append(textwrap.fill(", ".join(taglist), initial_indent="  ", subsequent_indent="  "))

--- a/tools/make-html.py
+++ b/tools/make-html.py
@@ -27,7 +27,7 @@ def xhtml2html(source, dest):
 
     # Report errors
     if xs.error:
-      print >>sys.stderr, "Error parsing XHTML file %s: %s" % (source, xs.error)
+      print >>sys.stderr, "Error parsing XHTML file {0!s}: {1!s}".format(source, xs.error)
 
     # Write
     f = open(dest, 'w')
@@ -43,11 +43,11 @@ elif len(sys.argv) == 2 and (sys.argv[1] != '--clobber' and sys.argv[1] != '-f')
     force   = False;
     root    = sys.argv[1]
 else:
-    print "make-html converts all %s XHTML files to %s HTML files." % (srcExt, dstExt)
+    print "make-html converts all {0!s} XHTML files to {1!s} HTML files.".format(srcExt, dstExt)
     print "Only changed files are converted, unless you specify -f."
     print "To use, specify the root directory of the files you want converted, e.g."
     print "  make-html ."
-    print "To delete all files with extension %s, specify the --clobber option." % dstExt
+    print "To delete all files with extension {0!s}, specify the --clobber option.".format(dstExt)
     exit()
 
 for root, dirs, files in os.walk(root):

--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -26,7 +26,7 @@ def fetch_submodules():
             finally:
                 os.chdir(orig_dir)
         else:
-            hg("clone", ("https://hg.csswg.org/dev/%s" % tool), dest_dir)
+            hg("clone", ("https://hg.csswg.org/dev/{0!s}".format(tool)), dest_dir)
 
 def update_dist():
     if not os.path.exists(built_dir) or not vcs.is_git_root(built_dir):
@@ -120,7 +120,7 @@ def commit(changeset):
     git = vcs.git
 
     msg = git("log", "-r", changeset, "-n", "1", "--pretty=%B", repo=source_dir)
-    msg = "%s\n\nBuild from revision %s" % (msg, changeset)
+    msg = "{0!s}\n\nBuild from revision {1!s}".format(msg, changeset)
 
     git("commit", "-m", msg, repo=built_dir)
 
@@ -130,7 +130,7 @@ def get_new_commits():
     with open(commit_path) as f:
         prev_commit = f.read().strip()
 
-    commit_range = "%s..%s" % (prev_commit, os.environ['TRAVIS_COMMIT'])
+    commit_range = "{0!s}..{1!s}".format(prev_commit, os.environ['TRAVIS_COMMIT'])
     commits = git("log", "--pretty=%H", "-r", commit_range).strip()
     if not commits:
         return []
@@ -145,7 +145,7 @@ def maybe_push():
 
     git = vcs.bind_to_repo(vcs.git, built_dir)
 
-    out = "https://%s@github.com/jgraham/css-test-built.git" % os.environ["TOKEN"]
+    out = "https://{0!s}@github.com/jgraham/css-test-built.git".format(os.environ["TOKEN"])
     git("remote", "add", "out", out, quiet=True)
 
     for i in range(2):

--- a/work-in-progress/mozilla/first-letter-characters/first-letter-characters-generator.py
+++ b/work-in-progress/mozilla/first-letter-characters/first-letter-characters-generator.py
@@ -52,7 +52,7 @@ class UnicodeTestGenerator:
            self.out.write(self.filefooter)
            self.out.close()
         self.filenum += 1
-        self.out = open(self.fileprefix + "%03d" % self.filenum + self.filesuffix, 'w')
+        self.out = open(self.fileprefix + "{0:03d}".format(self.filenum) + self.filesuffix, 'w')
         self.out.write(self.fileheader)
 
     def write(self):
@@ -79,9 +79,9 @@ class UnicodeTestGenerator:
                 if rangefirst >= breakat:
                     # we've exceeded our chunking size; break to a new file
                     self.startNewFile()
-                    print "Break at %x" % breakat
+                    print "Break at {0:x}".format(breakat)
                     breakat = (floor(rangefirst / self.blocksize) + 1) * self.blocksize
-                    print "Next break at %x" % breakat
+                    print "Next break at {0:x}".format(breakat)
                 for c in range(rangefirst, charcode + 1):
                     self.writeTest(c, ispunct)
                 rangefirst = None
@@ -91,9 +91,9 @@ class UnicodeTestGenerator:
                 if charcode >= breakat:
                     # we've exceeded our chunking size; break to a new file
                     self.startNewFile()
-                    print "Break %s at %x for %x" % (self.filenum, breakat, charcode)
+                    print "Break {0!s} at {1:x} for {2:x}".format(self.filenum, breakat, charcode)
                     breakat = (floor(charcode / self.blocksize) + 1) * self.blocksize
-                    print "Next break at %x" % breakat
+                    print "Next break at {0:x}".format(breakat)
                 self.writeTest(charcode, ispunct)
         self.out.write(self.filefooter)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:csswg-test?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:csswg-test?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
